### PR TITLE
(GH-2) Add `json_endpoint` parameter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,14 @@
 AllCops:
+  Exclude:
+    - pkg/**
+    - Gemfile
   TargetRubyVersion: 2.5
 
 # Layout cops
 # https://docs.rubocop.org/rubocop/cops_layout.html
+
+Layout/BeginEndAlignment:
+  Enabled: true
 
 Layout/ClosingHeredocIndentation:
   Enabled: false
@@ -39,6 +45,9 @@ Layout/SpaceAroundMethodCallOperator:
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
@@ -60,6 +69,12 @@ Lint/EmptyFile:
 Lint/FloatComparison:
   Enabled: true
 
+Lint/HashCompareByIdentity:
+  Enabled: false
+
+Lint/IdentityComparison:
+  Enabled: true
+
 Lint/MissingSuper:
   Enabled: false
 
@@ -72,6 +87,9 @@ Lint/OutOfRangeRegexpRef:
 Lint/RaiseException:
   Enabled: true
 
+Lint/RedundantSafeNavigation:
+  Enabled: true
+
 Lint/SelfAssignment:
   Enabled: true
 
@@ -79,7 +97,9 @@ Lint/StructNewOverride:
   Enabled: true
 
 Lint/SuppressedException:
-  Enabled: true
+  Exclude:
+    - lib/bolt/shell/bash.rb
+    - lib/bolt/module_installer.rb
 
 Lint/TopLevelReturnWithArgument:
   Enabled: true
@@ -92,6 +112,9 @@ Lint/UnreachableLoop:
 
 Lint/UselessMethodDefinition:
   Enabled: false
+
+Lint/UselessTimes:
+  Enabled: true
 
 # Metrics cops
 # https://docs.rubocop.org/rubocop/cops_metrics.html
@@ -142,6 +165,9 @@ Style/BlockDelimiters:
   Enabled: false
 
 Style/CaseLikeIf:
+  Enabled: true
+
+Style/ClassEqualityComparison:
   Enabled: true
 
 Style/CombinableLoops:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Release 0.2.0
+
+### New features
+
+- **Add `json_endpoint` parameter to `http_request` task**
+  ([#2](https://github.com/puppetlabs/puppetlabs-http_request/issues/2))
+
+  The `http_request` task now accepts a `json_endpoint` parameter. When set to
+  `true`, the task will convert the request body to JSON, set the `Content-Type`
+  header to `application/json`, and parse the response body as JSON.
+
 ## Release 0.1.0
 
 This is the initial release.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 1. [Parameters](#parameters)
 1. [Usage](#usage)
     - [Making a request](#making-a-request)
+    - [Making a JSON request](#making-a-json-request)
     - [Adding headers](#adding-headers)
     - [Adding a body](#adding-a-body)
 
@@ -28,9 +29,10 @@ This task requires Ruby to be installed on the target it runs on.
 
 ### `body`
 
-The request body.
+The request body. If json_endpoint is true, must be able representable as JSON.
+If json_endpoint is false, must be a string.
 
-- **Type:** `Optional[String]`
+- **Type:** `Optional[Data]`
 
 ### `cacert`
 
@@ -56,6 +58,14 @@ If `true`, automatically follows redirects.
 A map of headers to add to the payload.
 
 - **Type:** `Optional[Hash[String, String]]`
+
+### `json_endpoint`
+
+If `true`, parses the request and response bodies as JSON and sets the
+`Content-Type` header to `application/json`.
+
+- **Type:** `Boolean`
+- **Default:** `false`
 
 ### `key`
 
@@ -121,6 +131,43 @@ The simplest usage of this task is to make a GET request by only setting the
         base_url: 'http://httpbin.org/get'
 
   return: $request
+  ```
+
+### Making a JSON request
+
+If you are making a request to a JSON endpoint, you can configure the task to
+automatically convert the body to JSON, set the request headers, and parse
+the response body as JSON. To enable this behavior, set the `json_endpoint`
+parameter to `true`.
+
+- **Unix-like shell command**
+
+  ```shell
+  $ bolt task run http_request --targets localhost base_url=http://httpbin.org/get json_endpoint=true
+  ```
+
+- **PowerShell command**
+
+  ```powershell
+  > Invoke-BoltTask -Name 'http_request' -Targets 'localhost' base_url=http://httpbin.org/get json_endpoint=true
+  ```
+
+- **Plan step**
+
+  ```yaml
+  parameters:
+    targets:
+      type: TargetSpec
+
+  steps:
+    - name: request
+      task: http_request
+      targets: $targets
+      parameters:
+        base_url: 'http://httpbin.org/get'
+        json_endpoint: true
+
+  return: $request.first.value['body']['headers']['User-Agent']
   ```
 
 ### Adding headers

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-http_request",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "puppetlabs",
   "summary": "A task for making HTTP requests.",
   "license": "Apache-2.0",

--- a/spec/tasks/init_spec.rb
+++ b/spec/tasks/init_spec.rb
@@ -64,4 +64,52 @@ describe HTTPRequest do
     result = subject.task(opts)
     expect(result.key?(:_error)).to be(true)
   end
+
+  it 'errors if the body is not a String' do
+    opts = {
+      method:   'post',
+      base_url: "#{url}/post",
+      body:     { 'foo' => 'bar' }
+    }
+
+    result = subject.task(opts)
+    expect(result.key?(:_error)).to be(true)
+  end
+
+  context 'json_endpoint' do
+    let(:opts) do
+      {
+        method:        'get',
+        base_url:      "#{url}/headers",
+        json_endpoint: true
+      }
+    end
+
+    it 'sets the Content-Type header to application/json' do
+      result = subject.task(opts)
+      expect(result.dig(:body, 'headers', 'Content-Type')).to eq('application/json')
+    end
+
+    it 'allows Content-Type to be overwritten' do
+      opts.merge!(headers: { 'Content-Type' => 'text/plain' })
+      result = subject.task(opts)
+      expect(result.dig(:body, 'headers', 'Content-Type')).to eq('text/plain')
+    end
+
+    it 'formats body as JSON' do
+      body = {
+        'foo' => 'bar'
+      }
+
+      opts = {
+        method:        'post',
+        base_url:      "#{url}/anything",
+        json_endpoint: true,
+        body:          body
+      }
+
+      result = subject.task(opts)
+      expect(result.dig(:body, 'json')).to eq(body)
+    end
+  end
 end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -7,8 +7,8 @@
       "type": "String[1]"
     },
     "body": {
-      "description": "The request body.",
-      "type": "Optional[String]"
+      "description": "The request body. If json_endpoint is true, must be able representable as JSON. If json_endpoint is false, must be a string.",
+      "type": "Optional[Data]"
     },
     "cacert": {
       "description": "An absolute path to the CA certificate.",
@@ -26,6 +26,11 @@
     "headers": {
       "description": "A map of headers to add to the payload.",
       "type": "Optional[Hash[String, String]]"
+    },
+    "json_endpoint": {
+      "description": "If true, parses the request and response bodies as JSON and sets the Content-Type header to application/json.",
+      "type": "Boolean",
+      "default": false
     },
     "key": {
       "description": "An absolute path to the RSA keypair.",


### PR DESCRIPTION
This adds a `json_endpoint` parameter to the `http_request` task. When
set to `true`, the task will automatically convert the request body to
JSON, set the `Content-Type` header to `application/json`, and parse the
response body as JSON.