### PR TITLE
Fix handling of headers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
           ruby-version: '2.5.x'
       - name: Install bundler
         run: |
-          gem install bundler
+          gem install bundler -v 2.1.4
           bundle config path vendor/bundle
       - name: Cache gems
         id: cache

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -126,7 +126,7 @@ class HTTPRequest < TaskHelper
   # overridden by a user.
   def format_headers(headers, json)
     default = json ? { 'Content-Type' => 'application/json' } : {}
-    default.merge(headers || {})
+    default.merge(headers || {}).transform_keys(&:to_s)
   end
 
   # Parses the redirect URL and expands it relative to the


### PR DESCRIPTION
- ~~Convert to use PDK structure~~

- ~~Use exception handling instead of checking for file~~

- Fix handling of headers

	Headers will be provided as symbols after a [change in `ruby_task_helper`][0], hence those needs to be converted back to strings before being passed to `Net::Http`.

- ~~Fix validation lints~~

	~~The file [`files/task_helper.rb` is directly downloaded][1] and should hence NOT be a part of linting.~~

[0]: https://github.com/puppetlabs/puppetlabs-ruby_task_helper/pull/3
[1]: https://github.com/puppetlabs/puppetlabs-ruby_task_helper
