### PR TITLE
correct description for key task parameter

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -63,7 +63,7 @@ class HTTPRequest < TaskHelper
       client.verify_mode = OpenSSL::SSL::VERIFY_PEER
       client.ca_file     = opts[:cacert] if opts[:cacert]
       client.cert        = OpenSSL::X509::Certificate.new(File.read(opts[:cert])) if opts[:cert]
-      client.key         = OpenSSL::PKey::RSA.new(opts[:key]) if opts[:key]
+      client.key         = OpenSSL::PKey::RSA.new(File.read(opts[:key])) if opts[:key]
     end
 
     # Build the request


### PR DESCRIPTION
update parameter description to reflect key should be contents not absolute path to file

The key parameter is passed to [`OpenSSL::PKey::RSA.new()`](https://ruby-doc.org/stdlib-2.6.1/libdoc/openssl/rdoc/OpenSSL/PKey/RSA.html#method-c-new) which "Generates or loads an RSA keypair. If an integer key_size is given it represents the desired key size. Keys less than 1024 bits should be considered insecure. A key can instead be loaded from an encoded_key which must be PEM or DER encoded. [...]".