### PR TITLE
(GH-10) Update 'method' parameter to accept `patch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The maximum number of redirects to follow when `follow_redirects` is `true`.
 
 The HTTP method to use.
 
-- **Type:** `Enum[delete, get, post, put]`
+- **Type:** `Enum[delete, get, post, put, patch]`
 - **Default:** `get`
 
 ### `path`

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -43,7 +43,7 @@
     },
     "method": {
       "description": "The HTTP method to use.",
-      "type": "Enum[delete, get, post, put]",
+      "type": "Enum[delete, get, post, put, patch]",
       "default": "get"
     },
     "path": {


### PR DESCRIPTION
This patch adds the keyword `patch` to the Enum of keywords that the method parameter accepts.
This adds support for REST APIs that accept changes with PATCH in addition to PUT.

closes #10