### PR TITLE
Handle valid empty-body HTTP responses when json

### DIFF
--- a/spec/tasks/init_spec.rb
+++ b/spec/tasks/init_spec.rb
@@ -83,7 +83,7 @@ describe HTTPRequest do
     expect(result.key?(:_error)).to be(true)
   end
 
-  it 'errors if the body is not a String' do
+  it 'errors if the request body is not a String' do
     opts = {
       method:   'post',
       base_url: "#{url}/post",
@@ -141,6 +141,20 @@ describe HTTPRequest do
       _ = handler.task(opts)
 
       expect(stub).to have_been_requested.once
+    end
+  end
+
+  context 'when an empty response body is received' do
+    it 'gracefully returns nil' do
+      stub_request(:post, "#{url}/post")
+        .to_return(status: 204, body: nil)
+      opts = {
+        method:   'post',
+        base_url: "#{url}/post"
+      }
+      result = handler.task(opts)
+      expect(result.keys).to match_array(success_keys)
+      expect(result[:body]).to be_nil
     end
   end
 end

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -83,6 +83,8 @@ class HTTPRequest < TaskHelper
 
   # Parses the response body.
   def parse_response_body(response, json)
+    return nil unless response.read_body
+
     body = encode_body(response.read_body, response.type_params['charset'])
 
     if json


### PR DESCRIPTION
This patch gracefully handles HTTP responses with empty message
bodies.

Prior to this patch, a contentless [HTTP 204] (No Content) response
would crash the task (when the `json_endpoint` was `true`) with the error:

          undefined method `encode' for nil:NilClass`
    
[HTTP 204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204